### PR TITLE
Add inbox web UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 from typing import List
@@ -14,8 +16,19 @@ from app.schemas import schemas
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Agent Suite", version="0.1.0")
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
 security = HTTPBearer()
 settings = get_settings()
+
+
+@app.get("/inbox", include_in_schema=False)
+def inbox_page():
+    return FileResponse("app/static/index.html")
+
+
+@app.get("/compose", include_in_schema=False)
+def compose_page():
+    return FileResponse("app/static/index.html")
 
 
 def get_inbox_by_api_key(api_key: str, db: Session):

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,53 @@
+const app = document.getElementById('app');
+const apiKeyStore = 'agent-suite-api-key';
+let selectedMessage = null;
+function apiKey(){ return localStorage.getItem(apiKeyStore) || ''; }
+function setApiKey(value){ localStorage.setItem(apiKeyStore, value.trim()); }
+function authHeaders(){ return { 'Authorization': `Bearer ${apiKey()}`, 'Content-Type': 'application/json' }; }
+function escapeHtml(value=''){ return value.replace(/[&<>'"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c])); }
+function showError(message){ return `<div class="card error">${escapeHtml(message)}</div>`; }
+function keyBar(){ return `<div class="toolbar card"><label>API key<input id="api-key" placeholder="Bearer API key" value="${escapeHtml(apiKey())}" /></label><button id="save-key">Save key</button><button id="refresh">Refresh</button></div>`; }
+async function fetchMessages(){
+  const res = await fetch('/v1/inboxes/me/messages', { headers: authHeaders() });
+  if(!res.ok) throw new Error(await res.text() || `Failed to load messages (${res.status})`);
+  return res.json();
+}
+function messageButton(msg, i){
+  const date = msg.received_at ? new Date(msg.received_at).toLocaleString() : '';
+  return `<button class="message ${selectedMessage?.id === msg.id ? 'active' : ''}" data-index="${i}"><strong>${escapeHtml(msg.subject || '(no subject)')}</strong><div class="meta">${escapeHtml(msg.sender || 'unknown sender')}</div><div class="meta">${escapeHtml(date)}</div></button>`;
+}
+function detail(msg){
+  if(!msg) return `<section class="card detail"><p>Select a message to read it.</p></section>`;
+  const body = msg.body_text || msg.body_html || '';
+  return `<section class="card detail"><div class="meta">From ${escapeHtml(msg.sender || '')} to ${escapeHtml(msg.recipient || '')}</div><h2>${escapeHtml(msg.subject || '(no subject)')}</h2><div class="body">${escapeHtml(body)}</div></section>`;
+}
+async function renderInbox(){
+  app.innerHTML = keyBar() + `<div class="grid"><section class="card"><p>Loading messages...</p></section>${detail(null)}</div>`;
+  wireKeyBar(renderInbox);
+  try{
+    const data = await fetchMessages();
+    const messages = data.messages || [];
+    if(!selectedMessage && messages.length) selectedMessage = messages[0];
+    app.querySelector('.grid').innerHTML = `<section class="card"><h2>Inbox</h2><div class="message-list">${messages.map(messageButton).join('') || '<p>No messages yet.</p>'}</div></section>${detail(selectedMessage)}`;
+    app.querySelectorAll('.message').forEach(btn => btn.addEventListener('click', () => { selectedMessage = messages[Number(btn.dataset.index)]; renderInbox(); }));
+  } catch(err){ app.innerHTML = keyBar() + showError(err.message); wireKeyBar(renderInbox); }
+}
+function renderCompose(status=''){
+  app.innerHTML = keyBar() + `<section class="card"><h2>Compose</h2>${status}<form id="compose-form"><label>To<input name="to" type="email" required /></label><label>Subject<input name="subject" required /></label><label>Body<textarea name="body" required></textarea></label><div class="actions"><button type="submit">Send email</button><a class="button" href="/inbox">Back to inbox</a></div></form></section>`;
+  wireKeyBar(() => renderCompose());
+  document.getElementById('compose-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const form = new FormData(event.target);
+    try{
+      const res = await fetch('/v1/inboxes/me/send', { method:'POST', headers: authHeaders(), body: JSON.stringify(Object.fromEntries(form)) });
+      if(!res.ok) throw new Error(await res.text() || `Failed to send (${res.status})`);
+      renderCompose('<p class="success">Message sent.</p>');
+    } catch(err){ renderCompose(showError(err.message)); }
+  });
+}
+function wireKeyBar(afterSave){
+  document.getElementById('save-key')?.addEventListener('click', () => { setApiKey(document.getElementById('api-key').value); afterSave(); });
+  document.getElementById('refresh')?.addEventListener('click', afterSave);
+}
+function route(){ selectedMessage = null; location.pathname.startsWith('/compose') ? renderCompose() : renderInbox(); }
+route();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Agent Suite Inbox</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <h1>Agent Suite</h1>
+      <p>Email inbox UI for humans and agents</p>
+    </div>
+    <nav>
+      <a href="/inbox">Inbox</a>
+      <a href="/compose">Compose</a>
+    </nav>
+  </header>
+  <main id="app" class="shell"></main>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,24 @@
+:root { color-scheme: dark; --bg:#0f172a; --panel:#111827; --muted:#94a3b8; --text:#e5e7eb; --brand:#38bdf8; --danger:#f87171; --ok:#34d399; --border:#263244; }
+* { box-sizing: border-box; }
+body { margin:0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; background:linear-gradient(135deg,#0f172a,#111827 60%,#0b1120); color:var(--text); min-height:100vh; }
+a { color:inherit; text-decoration:none; }
+.topbar { display:flex; justify-content:space-between; gap:1rem; align-items:center; padding:1.2rem clamp(1rem,4vw,3rem); border-bottom:1px solid var(--border); background:rgba(15,23,42,.85); position:sticky; top:0; backdrop-filter: blur(10px); }
+h1 { margin:0; font-size:1.5rem; } p { color:var(--muted); } .topbar p { margin:.2rem 0 0; }
+nav { display:flex; gap:.8rem; flex-wrap:wrap; } nav a, button, .button { border:1px solid var(--border); background:#1e293b; color:var(--text); border-radius:12px; padding:.7rem 1rem; cursor:pointer; font-weight:600; }
+nav a:hover, button:hover, .button:hover { border-color:var(--brand); }
+.shell { width:min(1120px,100%); margin:0 auto; padding:1.5rem; }
+.card { background:rgba(17,24,39,.92); border:1px solid var(--border); border-radius:18px; box-shadow:0 16px 60px rgba(0,0,0,.25); padding:1rem; }
+.grid { display:grid; grid-template-columns: 360px 1fr; gap:1rem; }
+.toolbar { display:flex; gap:.75rem; align-items:end; margin-bottom:1rem; flex-wrap:wrap; }
+label { display:grid; gap:.35rem; color:var(--muted); font-size:.9rem; flex:1; }
+input, textarea { width:100%; border:1px solid var(--border); background:#020617; color:var(--text); border-radius:12px; padding:.8rem; }
+textarea { min-height:220px; resize:vertical; }
+.message-list { display:grid; gap:.6rem; max-height:68vh; overflow:auto; }
+.message { text-align:left; display:block; width:100%; border:1px solid var(--border); background:#0b1220; padding:.8rem; border-radius:14px; }
+.message.active { border-color:var(--brand); background:#102033; }
+.message strong, .detail h2 { display:block; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.meta { color:var(--muted); font-size:.86rem; margin-top:.25rem; }
+.detail { min-height:360px; } .body { white-space:pre-wrap; line-height:1.55; margin-top:1rem; color:#dbeafe; }
+.error { border-color:#7f1d1d; background:#2f1518; color:#fecaca; } .success { color:var(--ok); }
+.actions { display:flex; gap:.75rem; margin-top:1rem; align-items:center; flex-wrap:wrap; }
+@media (max-width: 760px) { .topbar { align-items:flex-start; flex-direction:column; } .grid { grid-template-columns:1fr; } .message-list { max-height:45vh; } }


### PR DESCRIPTION
## Summary
- add a static FastAPI-served inbox UI at `/inbox`
- add `/compose` for sending email through the existing API
- store API key in `localStorage`
- list messages from `/v1/inboxes/me/messages`, show selected message details, and handle API errors
- include responsive dark-mode styling for mobile and desktop

## Validation
- `python3 -m py_compile app/main.py`
- attempted `python3 -m pytest -q`; after installing missing `email-validator`, collection reaches existing Postgres dependency and fails because local PostgreSQL is not running on localhost:5432

Refs dmb4086/agentwork-infrastructure#1
Accepting this bounty
